### PR TITLE
Check for more wsfunction errors

### DIFF
--- a/moodle-quiz-archive-worker.py
+++ b/moodle-quiz-archive-worker.py
@@ -163,7 +163,7 @@ def handle_archive_request():
 
         # Probe moodle API (wstoken validity)
         if not probe_moodle_webservice_api(job_request.moodle_ws_url, job_request.wstoken):
-            return error_response(f'Could not establish a connection to Moodle webservice API at "{job_request.moodle_ws_url}" using the prodived wstoken.', HTTPStatus.BAD_REQUEST)
+            return error_response(f'Could not establish a connection to Moodle webservice API at "{job_request.moodle_ws_url}" using the provided wstoken.', HTTPStatus.BAD_REQUEST)
 
         # Enqueue request
         job = QuizArchiveJob(uuid.uuid1(), job_request)

--- a/quiz_archive_job.py
+++ b/quiz_archive_job.py
@@ -367,8 +367,12 @@ class QuizArchiveJob:
             raise ConnectionError(f'Call to Moodle webservice function {Config.MOODLE_WSFUNCTION_ARCHIVE} at "{self.request.moodle_ws_url}" failed')
 
         # Check if Moodle wsfunction returned an error
-        if 'errorcode' in data and 'debuginfo' in data:
-            raise RuntimeError(f'Moodle webservice function {Config.MOODLE_WSFUNCTION_ARCHIVE} returned error "{data["errorcode"]}". Message: {data["debuginfo"]}')
+        if 'errorcode' in data:
+            if 'debuginfo' in data:
+                raise RuntimeError(f'Moodle webservice function {Config.MOODLE_WSFUNCTION_ARCHIVE} returned error "{data["errorcode"]}". Message: {data["debuginfo"]}')
+            if 'message' in data:
+                raise RuntimeError(f'Moodle webservice function {Config.MOODLE_WSFUNCTION_ARCHIVE} returned error "{data["errorcode"]}". Message: {data["message"]}')
+            raise RuntimeError(f'Moodle webservice function {Config.MOODLE_WSFUNCTION_ARCHIVE} returned error "{data["errorcode"]}".')
 
         # Check if response is as expected
         for attr in ['attemptid', 'cmid', 'courseid', 'quizid', 'filename', 'report', 'attachments']:


### PR DESCRIPTION
For some reason I don't know yet, my totara returns `{'exception': 'Error', 'errorcode': None, 'message': 'Call to a member function get_course() on null'}` as response.
This case is clearly an error, but was previously skipped and the "incomplete response" error was raised.


And also fix another typo.