### PR TITLE
Add custom Playwright BrowserContext navigation timeout.

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ using the following environment variables:
 - `QUIZ_ARCHIVER_WAIT_FOR_READY_SIGNAL`: Whether to wait for the ready signal from the report page JS before generating the export (default=`True`)
 - `QUIZ_ARCHIVER_WAIT_FOR_READY_SIGNAL_TIMEOUT_SEC`: Number of seconds to wait for the ready signal from the report page JS before generating the export (default=`15`)
 - `QUIZ_ARCHIVER_CONTINUE_AFTER_READY_SIGNAL_TIMEOUT`: Whether to continue with the export if the ready signal was not received in time (default=`False`)
+- `QUIZ_ARCHIVER_WAIT_FOR_NAVIGATION_TIMEOUT_SEC`: Number of seconds to wait for the report page to load before aborting the job (default=`30`)
 
 
 ## License

--- a/config.py
+++ b/config.py
@@ -71,6 +71,9 @@ class Config:
     REPORT_CONTINUE_AFTER_READY_SIGNAL_TIMEOUT = bool(os.getenv('QUIZ_ARCHIVER_CONTINUE_AFTER_READY_SIGNAL_TIMEOUT', default=False))
     """Whether to continue with the export if the ready signal was not received in time"""
 
+    REPORT_WAIT_FOR_NAVIGATION_TIMEOUT_SEC = int(os.getenv('QUIZ_ARCHIVER_WAIT_FOR_NAVIGATION_TIMEOUT_SEC', default=30))
+    """Number of seconds to wait for the report page to load before aborting the job"""
+
     MOODLE_WSFUNCTION_ARCHIVE = 'quiz_archiver_generate_attempt_report'
     """Name of the Moodle webservice function to call to trigger an quiz attempt export"""
 


### PR DESCRIPTION
Added setting to customize Playwright BrowserContext default navigation timeout. Helps prevent timeouts with long loading times (>30s).