### PR TITLE
Feature: Demo Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Version X.Y.Z (YYYY-MM-DD)
+
+- Add a demo mode to allow setting up a public quiz archive worker service for testing.
+  - In demo mode, a watermark will be added to all generated PDFs, only a
+    limited number of attempts will be exported per archive job, and only
+    placeholder Moodle backups are included.
+  - The demo mode is disabled by default and will only be used to provide a free
+    and publicly available quiz archive worker service to the community. This
+    allows testing the Moodle plugin without the need to set up a local quiz
+    archive worker service right away. Productive instances of the quiz archive
+    worker service will remain fully unaffected by this.
+ 
+
 ## Version 2.0.0 (2024-08-21)
 
 - Switch to semantic versioning (see README.md, Section: "Versioning and Compatibility")

--- a/README.md
+++ b/README.md
@@ -146,15 +146,15 @@ bug fixes, features, and optimizations.
 ### Compatibility Examples
 
 | Moodle Plugin | Archive Worker | Compatible |
-|------------|----------------|------------|
-| 1.0.0      | 1.0.0          | Yes        |
-| 1.2.3      | 1.0.0          | Yes        |
-| 1.0.0      | 1.1.2          | Yes        |
-| 2.1.4      | 2.0.1          | Yes        |
-|            |                |            |
-| 2.0.0      | 1.0.0          | No         |
-| 1.0.0      | 2.0.0          | No         |
-| 2.4.2      | 1.4.2          | No         |
+|---------------|----------------|------------|
+| 1.0.0         | 1.0.0          | Yes        |
+| 1.2.3         | 1.0.0          | Yes        |
+| 1.0.0         | 1.1.2          | Yes        |
+| 2.1.4         | 2.0.1          | Yes        |
+|               |                |            |
+| 2.0.0         | 1.0.0          | No         |
+| 1.0.0         | 2.0.0          | No         |
+| 2.4.2         | 1.4.2          | No         |
 
 
 ### Development / Testing Versions
@@ -187,6 +187,7 @@ using the following environment variables:
 - `QUIZ_ARCHIVER_CONTINUE_AFTER_READY_SIGNAL_TIMEOUT`: Whether to continue with the export if the ready signal was not received in time (default=`False`)
 - `QUIZ_ARCHIVER_WAIT_FOR_NAVIGATION_TIMEOUT_SEC`: Number of seconds to wait for the report page to load before aborting the job (default=`30`)
 - `QUIZ_ARCHIVER_REPORT_PREVENT_REDIRECT_TO_LOGIN`: Whether to supress all redirects to Moodle login pages (`/login/*.php`) after page load. This can occur, if dynamic ajax requests fail due to permission errors (default=`True`)
+- `QUIZ_ARCHIVER_DEMO_MODE`: Whether the app is running in demo mode. In demo mode, a watermark will be added to all generated PDFs, only a limited number of attempts will be exported per archive job, and only placeholder Moodle backups are included (default=`False`)
 
 
 # Development

--- a/archiveworker/moodle_quiz_archive_worker.py
+++ b/archiveworker/moodle_quiz_archive_worker.py
@@ -187,6 +187,11 @@ def run() -> None:
     logging.basicConfig(encoding='utf-8', format='[%(asctime)s] | %(levelname)-8s | %(name)s | %(message)s', level=Config.LOG_LEVEL)
     app.logger.info(f'Running {Config.APP_NAME} version {Config.VERSION} on log level {logging.getLevelName(Config.LOG_LEVEL)}')
 
+    # Print demo mode notice if enabled
+    if Config.DEMO_MODE:
+        app.logger.warning('---> ATTENTION: Running in demo mode! This will add a watermark to all generated PDFs, only a limited number of attempts will be exported per archive job, and only placeholder Moodle backups are included. <---')
+        app.logger.info('---> To disable demo mode, set the environment variable QUIZ_ARCHIVER_DEMO_MODE to "False". <---')
+
     # Handle DEBUG specifics
     if Config.LOG_LEVEL == logging.DEBUG:
         # Dump app config

--- a/archiveworker/quiz_archive_job.py
+++ b/archiveworker/quiz_archive_job.py
@@ -38,6 +38,7 @@ from config import Config
 from .custom_types import JobStatus, JobArchiveRequest, ReportSignal, BackupStatus
 from .moodle_api import MoodleAPI
 
+DEMOMODE_JAVASCRIPT = open(os.path.join(os.path.dirname(__file__), '../res/demomode.js')).read()
 READYSIGNAL_JAVASCRIPT = open(os.path.join(os.path.dirname(__file__), '../res/readysignal.js')).read()
 
 class QuizArchiveJob:
@@ -343,6 +344,10 @@ class QuizArchiveJob:
         except Exception:
             self.logger.error(f'Page did not load after {Config.REPORT_WAIT_FOR_NAVIGATION_TIMEOUT_SEC} seconds. Aborting ...')
             raise
+
+        # If in demo mode, inject watermark JS
+        if Config.DEMO_MODE:
+            await page.evaluate(DEMOMODE_JAVASCRIPT)
 
         # Wait for the page to report that is fully rendered, if enabled
         if Config.REPORT_WAIT_FOR_READY_SIGNAL:

--- a/config.py
+++ b/config.py
@@ -21,13 +21,16 @@ import os
 class Config:
 
     APP_NAME = "moodle-quiz-archive-worker"
-    """Name of this app."""
+    """Name of this app"""
 
     VERSION = "2.0.0"
-    """Version of this app."""
+    """Version of this app"""
 
     LOG_LEVEL = logging.getLevelNamesMapping()[os.getenv('QUIZ_ARCHIVER_LOG_LEVEL', default='INFO')]
     """Python Logger logging level"""
+
+    DEMO_MODE = bool(os.getenv('QUIZ_ARCHIVER_DEMO_MODE', default=True))
+    """Whether the app is running in demo mode. In demo mode, a watermark will be added to all generated PDFs, only a limited number of attempts will be exported per archive job, and only placeholder Moodle backups are included."""
 
     UNIT_TESTS_RUNNING = False
     """Whether unit tests are currently running. This should always be kept at `False` and is only changed by pytest."""

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ class Config:
     LOG_LEVEL = logging.getLevelNamesMapping()[os.getenv('QUIZ_ARCHIVER_LOG_LEVEL', default='INFO')]
     """Python Logger logging level"""
 
-    DEMO_MODE = bool(os.getenv('QUIZ_ARCHIVER_DEMO_MODE', default=True))
+    DEMO_MODE = bool(os.getenv('QUIZ_ARCHIVER_DEMO_MODE', default=False))
     """Whether the app is running in demo mode. In demo mode, a watermark will be added to all generated PDFs, only a limited number of attempts will be exported per archive job, and only placeholder Moodle backups are included."""
 
     UNIT_TESTS_RUNNING = False

--- a/res/demomode.js
+++ b/res/demomode.js
@@ -1,0 +1,68 @@
+/*
+ * Moodle Quiz Archive Worker
+ * Copyright (C) 2024 Niels Gandraß <niels@gandrass.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This script is injected if the archive worker is in demo mode. It inserts a
+ * "Demo Mode" watermark into the PDF pages.
+ */
+
+// "DEMO MODE" watermark
+const wrapper = document.createElement('div');
+const watermark = document.createElement('div');
+
+watermark.innerHTML = 'DEMO  MODE';
+Object.assign(watermark.style, {
+    width: 'calc(1.414*100vw)',
+    transformOrigin: 'center',
+    transform: 'rotate(45deg)',
+    fontSize: '186px',
+    color: 'rgba(0, 0, 0, 0.3)',
+    fontWeight: 'bold',
+    pointerEvents: 'none'
+});
+
+Object.assign(wrapper.style, {
+    position: 'fixed',
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -50%)',
+    zIndex: '9999',
+    textAlign: 'center'
+});
+
+wrapper.appendChild(watermark);
+document.body.appendChild(wrapper);
+
+// Demo mode information
+const info = document.createElement('div');
+
+info.innerHTML = 'This PDF was generated in <strong>demo mode</strong>. The watermark will not be present when using a ' +
+                 'productive quiz archive worker service.<br>For more information visit: ' +
+                 '<a href="https://quizarchiver.gandrass.de">https://quizarchiver.gandrass.de</a>';
+
+Object.assign(info.style, {
+    position: 'fixed',
+    bottom: '0',
+    left: '0',
+    zIndex: '9999',
+    width: '100%',
+    padding: '10px',
+    backgroundColor: 'rgba(220, 220, 220, 0.9)',
+});
+
+document.body.appendChild(info);


### PR DESCRIPTION
- Add a demo mode to allow setting up a public quiz archive worker service for testing.
  - In demo mode, a watermark will be added to all generated PDFs, only a limited number of attempts will be exported per archive job, and only placeholder Moodle backups are included.
  - The demo mode is disabled by default and will only be used to provide a free and publicly available quiz archive worker service to the community. This allows testing the Moodle plugin without the need to set up a local quiz archive worker service right away. Productive instances of the quiz archive worker service will remain fully unaffected by this.
