### PR TITLE
Fix parsing of boolean / int values during config tree building from environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version X.Y.Z (YYYY-MM-DD)
 
 - Add support for HTTP and SOCKS proxy servers (#16 - Thanks to @PhMemmel)
+- Fix parsing of boolean / int values during config tree building from environment variables
 
 
 ## Version 2.1.4 (2025-01-02)

--- a/config.py
+++ b/config.py
@@ -18,6 +18,39 @@ import logging
 import os
 
 
+def parse_env_variable(name, default=None, valtype=None) -> None | bool | int | str:
+    """
+    Parses an environment variable and returns it cast to the desired type.
+    Undefined variables will return the default value.
+
+    :param name: Name of the environment variable to evaluate
+    :param default: Default to return if the variable is not set
+    :param valtype: Force return type. Pass None for automatic type detection
+    :return: Parsed value
+    """
+    # Detect unset variables
+    value = os.getenv(name, default=None)
+    if value is None:
+        return default
+
+    # Forced type casts
+    if valtype is bool:
+        return value.lower() in ['true', '1']
+    if valtype is int:
+        return int(value)
+    if valtype is str:
+        return value
+
+    # Automatic type detection
+    if value.lower() in ['true', 'false']:
+        return value.lower() == 'true'
+    if value.lstrip('-+').isdigit():
+        return int(value)
+
+    # String fallback
+    return value
+
+
 class Config:
 
     APP_NAME = "moodle-quiz-archive-worker"
@@ -26,22 +59,22 @@ class Config:
     VERSION = "2.1.4"
     """Version of this app"""
 
-    LOG_LEVEL = logging.getLevelNamesMapping()[os.getenv('QUIZ_ARCHIVER_LOG_LEVEL', default='INFO')]
+    LOG_LEVEL = logging.getLevelNamesMapping()[parse_env_variable('QUIZ_ARCHIVER_LOG_LEVEL', default='INFO', valtype=str)]
     """Python Logger logging level"""
 
-    DEMO_MODE = bool(os.getenv('QUIZ_ARCHIVER_DEMO_MODE', default=False))
+    DEMO_MODE = parse_env_variable('QUIZ_ARCHIVER_DEMO_MODE', default=False, valtype=bool)
     """Whether the app is running in demo mode. In demo mode, a watermark will be added to all generated PDFs, only a limited number of attempts will be exported per archive job, and only placeholder Moodle backups are included."""
 
     UNIT_TESTS_RUNNING = False
     """Whether unit tests are currently running. This should always be kept at `False` and is only changed by pytest."""
 
-    SERVER_HOST = os.getenv('QUIZ_ARCHIVER_SERVER_HOST', default='0.0.0.0')
+    SERVER_HOST = parse_env_variable('QUIZ_ARCHIVER_SERVER_HOST', default='0.0.0.0', valtype=str)
     """Host for Flask to bind to"""
 
-    SERVER_PORT = os.getenv('QUIZ_ARCHIVER_SERVER_PORT', default='8080')
+    SERVER_PORT = parse_env_variable('QUIZ_ARCHIVER_SERVER_PORT', default='8080', valtype=int)
     """Port for Flask to listen on"""
 
-    PROXY_SERVER_URL = os.getenv('QUIZ_ARCHIVER_PROXY_SERVER_URL', default=None)
+    PROXY_SERVER_URL = parse_env_variable('QUIZ_ARCHIVER_PROXY_SERVER_URL', default=None, valtype=str)
     """URL of the proxy server to use for all playwright requests. HTTP and SOCKS proxies are supported. If not set, auto-detection will be performed. If set to false, no proxy will be used."""
 
     PROXY_USERNAME = None
@@ -50,52 +83,52 @@ class Config:
     PROXY_PASSWORD = None
     """Optional password to authenticate at the proxy server. Will be populated based on PROXY_SERVER_URL."""
 
-    PROXY_BYPASS_DOMAINS = os.getenv('QUIZ_ARCHIVER_PROXY_BYPASS_DOMAINS', default=None)
+    PROXY_BYPASS_DOMAINS = parse_env_variable('QUIZ_ARCHIVER_PROXY_BYPASS_DOMAINS', default=None, valtype=str)
     """Comma-separated list of domains that should always be accessed directly, bypassing the proxy"""
 
-    QUEUE_SIZE = int(os.getenv('QUIZ_ARCHIVER_QUEUE_SIZE', default=8))
+    QUEUE_SIZE = parse_env_variable('QUIZ_ARCHIVER_QUEUE_SIZE', default=8, valtype=int)
     """Maximum number of requests that are queued before returning an error."""
 
-    HISTORY_SIZE = int(os.getenv('QUIZ_ARCHIVER_HISTORY_SIZE', default=128))
+    HISTORY_SIZE = parse_env_variable('QUIZ_ARCHIVER_HISTORY_SIZE', default=128, valtype=int)
     """Maximum number of jobs to keep in the history before forgetting about them."""
 
-    STATUS_REPORTING_INTERVAL_SEC = int(os.getenv('QUIZ_ARCHIVER_STATUS_REPORTING_INTERVAL_SEC', default=15))
+    STATUS_REPORTING_INTERVAL_SEC = parse_env_variable('QUIZ_ARCHIVER_STATUS_REPORTING_INTERVAL_SEC', default=15, valtype=int)
     """Number of seconds to wait between job progress updates"""
 
-    REQUEST_TIMEOUT_SEC = int(os.getenv('QUIZ_ARCHIVER_REQUEST_TIMEOUT_SEC', default=(60 * 60)))
+    REQUEST_TIMEOUT_SEC = parse_env_variable('QUIZ_ARCHIVER_REQUEST_TIMEOUT_SEC', default=(60 * 60), valtype=int)
     """Number of seconds before execution of a single request is aborted."""
 
-    BACKUP_STATUS_RETRY_SEC = int(os.getenv('QUIZ_ARCHIVER_BACKUP_STATUS_RETRY_SEC', default=30))
+    BACKUP_STATUS_RETRY_SEC = parse_env_variable('QUIZ_ARCHIVER_BACKUP_STATUS_RETRY_SEC', default=30, valtype=int)
     """Number of seconds between status checks of pending backups via the Moodle API"""
 
-    DOWNLOAD_MAX_FILESIZE_BYTES = int(os.getenv('QUIZ_ARCHIVER_DOWNLOAD_MAX_FILESIZE_BYTES', default=(1024 * 10e6)))
+    DOWNLOAD_MAX_FILESIZE_BYTES = parse_env_variable('QUIZ_ARCHIVER_DOWNLOAD_MAX_FILESIZE_BYTES', default=int(1024 * 10e6), valtype=int)
     """Maximum number of bytes a generic Moodle file is allowed to have for downloading"""
 
-    BACKUP_DOWNLOAD_MAX_FILESIZE_BYTES = int(os.getenv('QUIZ_ARCHIVER_BACKUP_DOWNLOAD_MAX_FILESIZE_BYTES', default=(512 * 10e6)))
+    BACKUP_DOWNLOAD_MAX_FILESIZE_BYTES = parse_env_variable('QUIZ_ARCHIVER_BACKUP_DOWNLOAD_MAX_FILESIZE_BYTES', default=int(512 * 10e6), valtype=int)
     """Maximum number of bytes a backup is allowed to have for downloading"""
 
-    QUESTION_ATTACHMENT_DOWNLOAD_MAX_FILESIZE_BYTES = int(os.getenv('QUIZ_ARCHIVER_QUESTION_ATTACHMENT_DOWNLOAD_MAX_FILESIZE_BYTES', default=(128 * 10e6)))
+    QUESTION_ATTACHMENT_DOWNLOAD_MAX_FILESIZE_BYTES = parse_env_variable('QUIZ_ARCHIVER_QUESTION_ATTACHMENT_DOWNLOAD_MAX_FILESIZE_BYTES', default=int(128 * 10e6), valtype=int)
     """Maximum number of bytes a question attachment is allowed to have for downloading"""
 
-    REPORT_BASE_VIEWPORT_WIDTH = int(os.getenv('QUIZ_ARCHIVER_REPORT_BASE_VIEWPORT_WIDTH', default=1240))
+    REPORT_BASE_VIEWPORT_WIDTH = parse_env_variable('QUIZ_ARCHIVER_REPORT_BASE_VIEWPORT_WIDTH', default=1240, valtype=int)
     """Width of the viewport created for rendering quiz attempts in pixel"""
 
-    REPORT_PAGE_MARGIN = os.getenv('QUIZ_ARCHIVER_REPORT_PAGE_MARGIN', default='5mm')
+    REPORT_PAGE_MARGIN = parse_env_variable('QUIZ_ARCHIVER_REPORT_PAGE_MARGIN', default='5mm', valtype=str)
     """Margin (top, bottom, left, right) of the report PDF pages including unit (mm, cm, in, px)"""
 
-    REPORT_WAIT_FOR_READY_SIGNAL = bool(os.getenv('QUIZ_ARCHIVER_WAIT_FOR_READY_SIGNAL', default=True))
+    REPORT_WAIT_FOR_READY_SIGNAL = parse_env_variable('QUIZ_ARCHIVER_WAIT_FOR_READY_SIGNAL', default=True, valtype=bool)
     """Whether to wait for the ready signal from the report page JS before generating the export"""
 
-    REPORT_WAIT_FOR_READY_SIGNAL_TIMEOUT_SEC = int(os.getenv('QUIZ_ARCHIVER_WAIT_FOR_READY_SIGNAL_TIMEOUT_SEC', default=30))
+    REPORT_WAIT_FOR_READY_SIGNAL_TIMEOUT_SEC = parse_env_variable('QUIZ_ARCHIVER_WAIT_FOR_READY_SIGNAL_TIMEOUT_SEC', default=30, valtype=int)
     """Number of seconds to wait for the ready signal from the report page JS before considering the export as failed"""
 
-    REPORT_CONTINUE_AFTER_READY_SIGNAL_TIMEOUT = bool(os.getenv('QUIZ_ARCHIVER_CONTINUE_AFTER_READY_SIGNAL_TIMEOUT', default=False))
+    REPORT_CONTINUE_AFTER_READY_SIGNAL_TIMEOUT = parse_env_variable('QUIZ_ARCHIVER_CONTINUE_AFTER_READY_SIGNAL_TIMEOUT', default=False, valtype=bool)
     """Whether to continue with the export if the ready signal was not received in time"""
 
-    REPORT_WAIT_FOR_NAVIGATION_TIMEOUT_SEC = int(os.getenv('QUIZ_ARCHIVER_WAIT_FOR_NAVIGATION_TIMEOUT_SEC', default=30))
+    REPORT_WAIT_FOR_NAVIGATION_TIMEOUT_SEC = parse_env_variable('QUIZ_ARCHIVER_WAIT_FOR_NAVIGATION_TIMEOUT_SEC', default=30, valtype=int)
     """Number of seconds to wait for the report page to load before aborting the job"""
 
-    PREVENT_REDIRECT_TO_LOGIN = bool(os.getenv('QUIZ_ARCHIVER_PREVENT_REDIRECT_TO_LOGIN', default=True))
+    PREVENT_REDIRECT_TO_LOGIN = parse_env_variable('QUIZ_ARCHIVER_PREVENT_REDIRECT_TO_LOGIN', default=True, valtype=bool)
     """Whether to supress all redirects to Moodle login pages (`/login/*.php`) after page load. This can occur, if dynamic ajax requests due to with permission errors."""
 
     MOODLE_WSFUNCTION_ARCHIVE = 'quiz_archiver_generate_attempt_report'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,150 @@
+# Moodle Quiz Archive Worker
+# Copyright (C) 2025 Niels Gandraß <niels@gandrass.de>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import os
+
+import pytest
+
+from config import parse_env_variable
+
+
+class TestConfig:
+    """
+    Tests for the Config class
+    """
+
+    @pytest.mark.parametrize("envvar, default", [
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ_1337", None),
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ_42", "foo"),
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ_1337", "bar"),
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ_42", "baz"),
+    ])
+    def test_parse_env_variable_unset_default(self, envvar, default) -> None:
+        """
+        Tests that unset environment variables are parsed to their default value
+
+        :param envvar: Name of the env var
+        :param default: Default value to use if env var is unset
+        :return: None
+        """
+        os.environ.pop(envvar, None)
+
+        assert parse_env_variable(envvar, default) == default
+
+    @pytest.mark.parametrize("envvar, value, default", [
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ_1337", "foo", None),
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ_42", "baz", None),
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ_1337", "bar", "invalid"),
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ_42", "baz", "invalid"),
+    ])
+    def test_parse_env_variable_existing(self, envvar, value, default) -> None:
+        """
+        Tests that set environment variables are parsed to their value
+
+        :param envvar: Name of the env var
+        :param value: Value to set the env var to
+        :param default: Default value to use if env var is unset
+        :return: None
+        """
+        os.environ[envvar] = value
+        assert parse_env_variable(envvar, default) == value
+
+        os.environ.pop(envvar, None)
+        assert parse_env_variable(envvar, default) == default
+
+    @pytest.mark.parametrize("envvar, valtype, value, expected, shouldfail", [
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ", bool, "True", True, False),
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ", bool, "true", True, False),
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ", bool, "1", True, False),
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ", bool, "tru", False, False),
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ", bool, "False", False, False),
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ", bool, "false", False, False),
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ", bool, "0", False, False),
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ", bool, "", False, False),
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ", bool, "None", False, False),
+
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ", int, "1337", 1337, False),
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ", int, "42", 42, False),
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ", int, "-42", -42, False),
+
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ", str, "foo", "foo", False),
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ", str, "bar", "bar", False),
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ", str, "baz", "baz", False),
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ", str, "", "", False),
+
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ", int, "13xxx37", None, True),
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ", int, "zweiundvierzig", None, True),
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ", int, "", None, True),
+    ])
+    def test_parse_env_variable_typecast(self, envvar, valtype, value, expected, shouldfail) -> None:
+        """
+        Tests that environment variables are typecasted correctly
+
+        :param envvar: Name of the env var
+        :param valtype: Type to forcecast the env var to
+        :param value: Value to set the env var to
+        :param expected: Expected value after typecasting
+        :param shouldfail: Whether the test should fail
+        :return: None
+        """
+        os.environ[envvar] = value
+        if shouldfail:
+            with pytest.raises(ValueError):
+                assert parse_env_variable(envvar, None, valtype) == expected
+        else:
+            assert parse_env_variable(envvar, None, valtype) == expected
+            assert type(parse_env_variable(envvar, None, valtype)) == type(expected)
+
+        os.environ.pop(envvar, None)
+
+    @pytest.mark.parametrize("envvar, value, expected", [
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ", "True", True),
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ", "true", True),
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ", "False", False),
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ", "false", False),
+
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ", "1337", 1337),
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ", "42", 42),
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ", "-42", -42),
+
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ", "foo", "foo"),
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ", "bar", "bar"),
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ", "baz", "baz"),
+        ("QUIZ_ARCHIVER_FOO_BAR_BAZ", "", ""),
+    ])
+    def test_parse_env_variable_auto_typecast(self, envvar, value, expected) -> None:
+        """
+        Tests that environment variables are typecasted correctly
+
+        :param envvar: Name of the env var
+        :param value: Value to set the env var to
+        :param expected: Expected value after typecasting
+        :return: None
+        """
+        os.environ[envvar] = value
+        assert parse_env_variable(envvar, None) == expected
+        assert type(parse_env_variable(envvar, None)) == type(expected)
+        os.environ.pop(envvar, None)
+
+    def test_parse_env_variable_auto_typecast_unset(self) -> None:
+        """
+        Tests that the automatic type detection does not trigger for unset env vars
+        :return:
+        """
+        os.environ.pop("QUIZ_ARCHIVER_FOO_BAR_BAZ", None)
+        assert type(parse_env_variable("QUIZ_ARCHIVER_FOO_BAR_BAZ", None)) is type(None)
+        assert type(parse_env_variable("QUIZ_ARCHIVER_FOO_BAR_BAZ", None, bool)) is type(None)
+        assert type(parse_env_variable("QUIZ_ARCHIVER_FOO_BAR_BAZ", None, int)) is type(None)
+        assert type(parse_env_variable("QUIZ_ARCHIVER_FOO_BAR_BAZ", None, str)) is type(None)


### PR DESCRIPTION
This PR addresses https://github.com/ngandrass/moodle-quiz_archiver/issues/61

Changes specifically affect the parsing of the special string values "true", "false", "1", "0" and integer values. Those are converted to their respective types now.